### PR TITLE
feat: add userinfo & end_session endpoints in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -120,7 +120,7 @@ fi
 # Build an intermediate configuration file
 # File format is: <NGINX variable name><space><IdP value>
 #
-jq -r '. | "$oidc_authz_endpoint \(.authorization_endpoint)\n$oidc_token_endpoint \(.token_endpoint)\n$oidc_jwks_uri \(.jwks_uri)"' < /tmp/${COMMAND}_$$_json > /tmp/${COMMAND}_$$_conf
+jq -r '. | "$oidc_authz_endpoint \(.authorization_endpoint)\n$oidc_token_endpoint \(.token_endpoint)\n$oidc_jwks_uri \(.jwks_uri)\n$oidc_end_session_endpoint \(.end_session_endpoint)\n$oidc_userinfo_endpoint \(.userinfo_endpoint)"' < /tmp/${COMMAND}_$$_json > /tmp/${COMMAND}_$$_conf
 
 # Create a random value for HMAC key, adding to the intermediate configuration file
 echo "\$oidc_hmac_key `openssl rand -base64 18`" >> /tmp/${COMMAND}_$$_conf
@@ -178,7 +178,7 @@ fi
 
 # Loop through each configuration variable
 echo "$COMMAND: NOTICE: Configuring $CONFDIR/openid_connect_configuration.conf"
-for OIDC_VAR in \$oidc_authz_endpoint \$oidc_token_endpoint \$oidc_jwt_keyfile \$oidc_hmac_key $CLIENT_ID_VAR $CLIENT_SECRET_VAR $PKCE_ENABLE_VAR; do
+for OIDC_VAR in \$oidc_authz_endpoint \$oidc_token_endpoint \$oidc_jwt_keyfile \$oidc_end_session_endpoint \$oidc_userinfo_endpoint \$oidc_hmac_key $CLIENT_ID_VAR $CLIENT_SECRET_VAR $PKCE_ENABLE_VAR; do
 	# Pull the configuration value from the intermediate file
 	VALUE=`grep "^$OIDC_VAR " /tmp/${COMMAND}_$$_conf | cut -f2 -d' '`
 	echo -n "$COMMAND: NOTICE:  - $OIDC_VAR ..."


### PR DESCRIPTION
**Issue Item:**
  - https://github.com/nginx-openid-connect/nginx-oidc-core-v1/issues/6

**Background:**
- The `configure.sh` script currently supports to complete the following configuration if an IdP supports OpenID Connect Discovery (usually at the URI `/.well-known/openid-configuration`).
  - Obtain the URL for jwks_uri or download the JWK file to your NGINX Plus instance
  - Obtain the URL for the authorization endpoint
  - Obtain the URL for the token endpoint
- NGINX Plus OIDC additionally exposed the endpoints of user information and logout in the [PR](https://github.com/nginx-openid-connect/nginx-oidc-core-v1/issues/5). Hence they need to be configured by using `configure.sh`.

**Description:**
- Added two endpoints in the `configure.sh` to additionally complete the following configuration.
  - Obtain the URL for the user information endpoint of IdP.
  - Obtain the URL for the session end endpoint of IdP.
- Updated `README.md` in the issue of https://github.com/nginx-openid-connect/nginx-oidc-core-v1/issues/5.

**Compatibility:**
- This PR does not block the existing features as it just adds two endpoints.
